### PR TITLE
Fix travis and CS

### DIFF
--- a/libraries/ClassLoader.php
+++ b/libraries/ClassLoader.php
@@ -24,7 +24,7 @@ class JClassLoader
 	 *
 	 * @var \Composer\Autoload\ClassLoader
 	 */
-	 private $loader;
+	private $loader;
 
 	public function __construct(\Composer\Autoload\ClassLoader $loader)
 	{
@@ -33,7 +33,8 @@ class JClassLoader
 	
 	public function loadClass($class)
 	{
-		if($result = $this->loader->loadClass($class)) {
+		if ($result = $this->loader->loadClass($class))
+		{
 			\JLoader::applyAliasFor($class);
 			
 		}

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -33,8 +33,8 @@ JLoader::registerPrefix('J', JPATH_PLATFORM . '/cms', false, true);
 $loader = require_once JPATH_PLATFORM . '/vendor/autoload.php';
 $loader->unregister();
 
-/// Decorate Composer autoloader
-require_once JPATH_PLATFORM . '/classloader.php';
+// Decorate Composer autoloader
+require_once JPATH_PLATFORM . '/ClassLoader.php';
 spl_autoload_register(array(new JClassLoader($loader), 'loadClass'), true, true);
 
 // Register the class aliases for Framework classes that have replaced their Platform equivilents


### PR DESCRIPTION
@johanjanssens 

Can you have a look into this Pull that try to fix travis and CS issues with https://github.com/joomla/joomla-cms/pull/6335

e.g.

```
PHP Warning:  require_once(/home/travis/build/joomla/joomla-cms/libraries/classloader.php): failed to open stream: No such file or directory in /home/travis/build/joomla/joomla-cms/libraries/cms.php on line 37
```

As the file is called `ClassLoader.php` and not `classloader.php`

and also

```
FILE: /home/travis/build/joomla/joomla-cms/libraries/cms.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 36 | ERROR | Please put a space between the // and the start of comment text;
    |       | found "/// Decorate Composer autoloader"
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
```

Thanks for having a look into it :smile: 
